### PR TITLE
naked return example should be naked

### DIFF
--- a/chapters/basics.md
+++ b/chapters/basics.md
@@ -411,7 +411,7 @@ func location(name, city string) (name, country string) {
 	default:
 		country = "Unknown"
 	}
-	return city, country
+	return
 }
 
 func main() {


### PR DESCRIPTION
This should be naked if it is the named return parameter example. It is in the playground link IIUC.
