### PR TITLE
Better names for Go Tour pages

### DIFF
--- a/chapters/basics.md
+++ b/chapters/basics.md
@@ -214,8 +214,8 @@ import (
 )
 ```
 
-* [Go tour: Packages](http://tour.golang.org/basics/1)
-* [Go tour: Imports](http://tour.golang.org/basics/2)
+* [Go Tour: Packages](http://tour.golang.org/basics/1)
+* [Go Tour: Imports](http://tour.golang.org/basics/2)
 
 
 Usually, non standard lib packages are namespaced using a web
@@ -347,7 +347,7 @@ func main() {
 }
 ```
 
-* [Function example](http://tour.golang.org/#7)
+* [Go Tour Functions example](http://tour.golang.org/basics/4)
 
 In the following example, instead of declaring the type of each parameter,
 we only declare one type that applies to both.

--- a/chapters/basics.md
+++ b/chapters/basics.md
@@ -214,8 +214,8 @@ import (
 )
 ```
 
-* [Go tour page](http://tour.golang.org/basics/1)
-* [Go tour page 2](http://tour.golang.org/basics/2)
+* [Go tour: Packages](http://tour.golang.org/basics/1)
+* [Go tour: Imports](http://tour.golang.org/basics/2)
 
 
 Usually, non standard lib packages are namespaced using a web

--- a/chapters/types.md
+++ b/chapters/types.md
@@ -665,5 +665,5 @@ func main() {
 **Answer:** That is because methods defined on a pointer are also
 automatically available on the value itself. The example didn't use a
 pointer on purpose, so the dot notation was working right away. In the
-pointer solution, an zero value player is composed of a nil pointer of
+pointer solution, a zero value player is composed of a nil pointer of
 type `User` and therefore, we can't call a field on a nil pointer.


### PR DESCRIPTION
Came to correct the broken links at http://www.golangbootcamp.com/book/basics#sec-packages but seems they have been corrected already (but not deployed). Better names in case links break again in future.

Includes minor grammatical corrections as well.