### PR TITLE
Fix first 'Break & Continue' example to match the expected output.

### DIFF
--- a/chapters/collection_types.md
+++ b/chapters/collection_types.md
@@ -466,7 +466,7 @@ func main() {
 	pow := make([]int, 10)
 	for i := range pow {
 		pow[i] = 1 << uint(i)
-		if pow[i] > 16 {
+		if pow[i] >= 16 {
 			break
 		}
 	}
@@ -475,7 +475,7 @@ func main() {
 }
 ```
 
-* [See in Playground](http://play.golang.org/p/T65dcE8fZ7)
+* [See in Playground](http://play.golang.org/p/1S4ApCLxaD)
 
 
 You can also skip an iteration by using `continue`:


### PR DESCRIPTION
In section 4.3.1, the expected output of the first example (via the comment below the `Println` statement) is 

`[1 2 4 8 16 0 0 0 0 0]`

 but the actual output was 

`[1 2 4 8 16 32 0 0 0 0]`

This change forces the loop to break if `pow[i]` is greater than or equal to 16, instead of only when `pow[i]` is greater than.

This also includes an updated link to the [Playground example](http://play.golang.org/p/1S4ApCLxaD)