### PR TITLE
Fix all Tour of Go links: HTTPS, no anchor, new pages organization.

### DIFF
--- a/chapters/basics.md
+++ b/chapters/basics.md
@@ -214,8 +214,8 @@ import (
 )
 ```
 
-* [Go Tour: Packages](http://tour.golang.org/basics/1)
-* [Go Tour: Imports](http://tour.golang.org/basics/2)
+* [Go Tour: Packages](https://tour.golang.org/basics/1)
+* [Go Tour: Imports](https://tour.golang.org/basics/2)
 
 
 Usually, non standard lib packages are namespaced using a web
@@ -347,7 +347,7 @@ func main() {
 }
 ```
 
-* [Go Tour Functions example](http://tour.golang.org/basics/4)
+* [Go Tour Functions example](https://tour.golang.org/basics/4)
 
 In the following example, instead of declaring the type of each parameter,
 we only declare one type that applies to both.

--- a/chapters/collection_types.md
+++ b/chapters/collection_types.md
@@ -32,7 +32,7 @@ func main() {
 }
 ```
 
-[Golang tour page](http://tour.golang.org/#31)
+[Golang tour page](https://tour.golang.org/moretypes/6)
 
 
 You can also set the array entries as you declare the array:
@@ -171,7 +171,7 @@ func main() {
 }
 ```
 
-* [Go tour page](http://tour.golang.org/#33)
+* [Go tour page](https://tour.golang.org/moretypes/7)
 
 ### Slicing a slice
 
@@ -223,7 +223,7 @@ func main() {
 ```
 
 * [See in Playground](http://play.golang.org/p/2z_6hNt_Vg)
-* [Go tour page](http://tour.golang.org/#33)
+* [Go tour page](https://tour.golang.org/moretypes/8)
 
 
 ### Making slices
@@ -250,8 +250,6 @@ func main() {
 * [See in Playground](http://play.golang.org/p/CX5z79KYsK)
 
 It works by allocating a zeroed array and returning a slice that refers to that array.
-
-* [Go tour](http://tour.golang.org/#34)
 
 
 ### Appending to a slice
@@ -379,7 +377,7 @@ func main() {
 }
 ```
 * [See in Playground](http://play.golang.org/p/inw1CunExE)
-* [Go tour page](http://tour.golang.org/#35)
+* [Go tour page](https://tour.golang.org/moretypes/10)
 
 ### Resources
 
@@ -428,7 +426,7 @@ Which will print:
 2**7 = 128
 ```
 
-* [Go tour page](http://tour.golang.org/#36)
+* [Go tour page](https://tour.golang.org/moretypes/12)
 
 
 You can skip the index or value by assigning to `_`.
@@ -450,7 +448,7 @@ func main() {
 }
 ```
 
-* [Go tour page](http://tour.golang.org/#37)
+* [Go tour page](https://tour.golang.org/moretypes/13)
 
 ### Break & continue
 
@@ -751,7 +749,7 @@ func main() {
 ```
 
 * [See in Playground](http://play.golang.org/p/-7aN1ASYYx)
-* [Online assignment](http://tour.golang.org/#43)
+* [Online assignment](https://tour.golang.org/moretypes/19)
 
 
 It should return a map of the counts of each "word" in the string `s`.

--- a/chapters/concurrency.md
+++ b/chapters/concurrency.md
@@ -58,7 +58,7 @@ func main() {
 
 [See in playground](http://play.golang.org/p/6PHXHha_Uv)
 
-[Go tour page](http://tour.golang.org/#65)
+[Go tour page](https://tour.golang.org/concurrency/1)
 
 
 ## Channels
@@ -109,7 +109,7 @@ func main() {
 
 [See in playground](http://play.golang.org/p/E-U0Kfd4IE)
 
-[Go tour page](http://tour.golang.org/#66)
+[Go tour page](https://tour.golang.org/concurrency/2)
 
 ### Buffered channels
 
@@ -195,7 +195,7 @@ the goroutine will wait until the channel is available.
 We then read a first value from the channel, which frees a spot and
 our goroutine can push its value to the channel.
 
-[Go tour page](http://tour.golang.org/#67)
+[Go tour page](https://tour.golang.org/concurrency/3)
 
 ## Range and close
 \label{sec:range_close}
@@ -241,7 +241,7 @@ func main() {
 
 [See in playground](http://play.golang.org/p/qtNyWuqESE)
 
-[Go tour page](http://tour.golang.org/#68)
+[Go tour page](https://tour.golang.org/concurrency/4)
 
 ## Select
 \label{sec:select}
@@ -326,7 +326,7 @@ func main() {
 
 [See in playground](http://play.golang.org/p/s03PRK3FZe)
 
-[Go tour page](http://tour.golang.org/#70)
+[Go tour page](https://tour.golang.org/concurrency/6)
 
 ### Timeout
 
@@ -375,7 +375,7 @@ request didn't give a response within 200ms.
 ## Exercise: Equivalent Binary Trees
 \label{sec:exercise_equiv_bin_trees}
 
-[Online Assignment](http://tour.golang.org/#72)
+[Online Assignment](https://tour.golang.org/concurrency/7)
 
 There can be many different binary trees with the same sequence of values stored at the leaves. For example, here are two binary trees storing the sequence 1, 1, 2, 3, 5, 8, 13.
 

--- a/chapters/control_flow.md
+++ b/chapters/control_flow.md
@@ -11,7 +11,7 @@ Variables declared by the statement are only in scope until the end of
 the `if`.
 Variables declared inside an if short statement are also available inside any of the else blocks.
 
-* [`If` statement example](http://tour.golang.org/#22)
+* [`If` statement example](https://tour.golang.org/flowcontrol/)
 
 
 ```go
@@ -21,7 +21,7 @@ if answer != 42 {
 ```
 
 
-* [`If` with a short statement](http://tour.golang.org/#23)
+* [`If` with a short statement](https://tour.golang.org/flowcontrol/6)
 
 
 ```go
@@ -30,7 +30,7 @@ if err := foo(); err != nil {
 }
 ```
 
-* [`If` and `else` example](http://tour.golang.org/#24)
+* [`If` and `else` example](https://tour.golang.org/flowcontrol/7)
 
 
 ## For Loop
@@ -41,7 +41,7 @@ The basic for loop looks as it does in C or Java, except that the ( ) are gone (
 As in C or Java, you can leave the pre and post statements empty.
 
 
-* [For loop example](http://tour.golang.org/#18)
+* [For loop example](https://tour.golang.org/flowcontrol/1)
 
 ```go
 sum := 0
@@ -50,7 +50,7 @@ for i := 0; i < 10; i++ {
 }
 ```
 
-* [For loop without pre/post statements](http://tour.golang.org/#19)
+* [For loop without pre/post statements](https://tour.golang.org/flowcontrol/2)
 
 ```go
 sum := 1
@@ -59,7 +59,7 @@ for ; sum < 1000; {
 }
 ```
 
-* [For loop as a `while` loop](http://tour.golang.org/#20)
+* [For loop as a `while` loop](https://tour.golang.org/flowcontrol/3)
 
 ```go
 sum := 1
@@ -68,7 +68,7 @@ for sum < 1000 {
 }
 ```
 
-* [Infinite loop](http://tour.golang.org/#21)
+* [Infinite loop](https://tour.golang.org/flowcontrol/4)
 
 ```go
 for {

--- a/chapters/interfaces.md
+++ b/chapters/interfaces.md
@@ -189,7 +189,7 @@ func main() {
 ## Exercise: Errors
 \label{sec:exercise_errors}
 
-[Online assignment](http://tour.golang.org/#58)
+[Online assignment](https://tour.golang.org/methods/9)
 
 Copy your `Sqrt` function from the earlier exercises (Section~\ref{sec:exercise_loops_and_funcs}) and modify it to return an `error` value.
 

--- a/chapters/intro.md
+++ b/chapters/intro.md
@@ -20,7 +20,7 @@ Git hosting for this book is provided by [GitHub](https://github.com)
 and is available [here](https://github.com/gobootcamp/book).
 
 This companion book contains material initially written specifically
-for this event as well as content from Google & the [Go team](http://tour.golang.org/) under [Creative Commons Attribution
+for this event as well as content from Google & the [Go team](https://tour.golang.org/) under [Creative Commons Attribution
 3.0 License](http://creativecommons.org/licenses/by/3.0/) and code under licensed under a BSD license.
 The rest of of the content is also provided under [Creative Commons Attribution
 3.0 License](http://creativecommons.org/licenses/by/3.0/).

--- a/chapters/methods.md
+++ b/chapters/methods.md
@@ -48,8 +48,6 @@ been writing Object Oriented code for a while, you might find that a
 bit odd at first. The method on the `User` type could be defined
 anywhere in the package.
 
-[Go tour page](http://tour.golang.org/#52)
-
 ## Code organization
 
 Methods can be defined on any file in the package, but my
@@ -156,7 +154,7 @@ func main() {
 }
 ```
 
-[Playground Example](http://tour.golang.org/#53)
+[Playground Example](https://tour.golang.org/methods/2)
 
 
 ## Method receivers
@@ -237,6 +235,6 @@ However `Scale()` has to be defined on a pointer since it does modify the receiv
 `Scale()` resets the values of the `X` and `Y` fields.
 
 
-[Go tour page](http://tour.golang.org/#54)
+[Go tour page](https://tour.golang.org/methods/3)
 
 

--- a/chapters/tour_of_go.md
+++ b/chapters/tour_of_go.md
@@ -9,7 +9,7 @@ in just a few pages.
 
 Here are the concepts we are going to explore before writing our
 first application. To walk through these various concepts, we are
-going to use Go's official [Tour of Go](http://tour.golang.org/) web
+going to use Go's official [Tour of Go](https://tour.golang.org/) web
 application. 
 
 ## Basic Concepts
@@ -21,11 +21,11 @@ Every Go program is made up of packages.
 Programs start running in package main.
 By convention, the package name is the same as the last element of the import path. For instance, the "math/rand" package comprises files that begin with the statement package rand.
 
-[Package example](http://tour.golang.org/#4)
+[Package example](https://tour.golang.org/basics/1)
 
 ### Imports
 
-* [Imports example](http://tour.golang.org/#5)
+* [Imports example](https://tour.golang.org/basics/2)
 
 ### Exported names
 
@@ -33,7 +33,7 @@ After importing a package, you can refer to the names it exports.
 In Go, a name is exported if it begins with a capital letter.
 `Foo` is an exported name, as is `FOO`. The name `foo` is not exported.
 
-* [Exported names example](http://tour.golang.org/#6)
+* [Exported names example](https://tour.golang.org/basics/3)
 
 ### Functions, signature, return values, named results
 
@@ -43,10 +43,10 @@ Functions can be defined to return any number of values.
 Return values are always typed.
 
 
-* [Function example](http://tour.golang.org/#7)
-* [Function with arguments sharing the same type](http://tour.golang.org/#8)
-* [Function with multiple results](http://tour.golang.org/#9)
-* [Function with named results](http://tour.golang.org/#10)
+* [Function example](https://tour.golang.org/basics/4)
+* [Function with arguments sharing the same type](https://tour.golang.org/basics/5)
+* [Function with multiple results](https://tour.golang.org/basics/6)
+* [Function with named results](https://tour.golang.org/basics/7)
 
 #### Resources
 
@@ -62,9 +62,9 @@ Inside a function, the `:=` short assignment statement can be used in place of a
 Outside a function, every construct begins with a keyword (`var`,
 `func`, and so on) and the `:=` construct is not available.
 
-* [Variables example](http://tour.golang.org/#11)
-* [Initialization of variables](http://tour.golang.org/#12)
-* [Short variable declaration: `:=`](http://tour.golang.org/#13)
+* [Variables example](https://tour.golang.org/basics/8)
+* [Initialization of variables](https://tour.golang.org/basics/9)
+* [Short variable declaration: `:=`](https://tour.golang.org/basics/10)
 
 
 ### Basic types
@@ -87,7 +87,7 @@ float32 float64
 complex64 complex128
 ```
 
-* [Basic types example](http://tour.golang.org/#14)
+* [Basic types example](https://tour.golang.org/basics/11)
 
 ### Type conversion
 
@@ -108,7 +108,7 @@ u := uint(f)
 ```
 Go assignment between items of different type requires an explicit conversion. 
 
-* [Type conversion example](http://tour.golang.org/#15)
+* [Type conversion example](https://tour.golang.org/basics/13)
 
 
 ### Constants
@@ -131,8 +131,8 @@ const (
 )
 ```
 
-* [Constants example](http://tour.golang.org/#16)
-* [Numeric Constants](http://tour.golang.org/#17)
+* [Constants example](https://tour.golang.org/basics/15)
+* [Numeric Constants](https://tour.golang.org/basics/16)
 
 ### For Loop
 
@@ -167,10 +167,10 @@ for {
 }
 ```
 
-* [For loop example](http://tour.golang.org/#18)
-* [For loop without pre/post statements](http://tour.golang.org/#19)
-* [For loop as a `while` loop](http://tour.golang.org/#20)
-* [Infinite loop](http://tour.golang.org/#21)
+* [For loop example](https://tour.golang.org/flowcontrol/1)
+* [For loop without pre/post statements](https://tour.golang.org/flowcontrol/2)
+* [For loop as a `while` loop](https://tour.golang.org/flowcontrol/3)
+* [Infinite loop](https://tour.golang.org/flowcontrol/4)
 
 ### If statement
 
@@ -192,14 +192,14 @@ if err := foo(); err != nil {
 }
 ```
 
-* [`If` statement](http://tour.golang.org/#22)
-* [`If` with a short statement](http://tour.golang.org/#23)
-* [`If` and `else` example](http://tour.golang.org/#24)
+* [`If` statement](https://tour.golang.org/flowcontrol/5)
+* [`If` with a short statement](https://tour.golang.org/flowcontrol/6)
+* [`If` and `else` example](https://tour.golang.org/flowcontrol/7)
 
 
 ###Exercises
 
-[Loops and Functions exercise](http://tour.golang.org/#25)
+[Loops and Functions exercise](https://tour.golang.org/flowcontrol/8)
 
 **Solutions**:
 

--- a/config/marketing.yml
+++ b/config/marketing.yml
@@ -51,7 +51,7 @@ faq:
     answer: "No, all code examples can be executed and modified from your browser as long as have you internet."
   -
     question: "Some of the material seems familiar"
-    answer: "The book is largely based on the [Go tour](http://tour.golang.org/)"
+    answer: "The book is largely based on the [Go tour](https://tour.golang.org/)"
 
 testimonials:
   -


### PR DESCRIPTION
Official Go Tour URLs have changed. Old links are dead. Also, HTTPS seems to be the "prefered" protocol (according to Google results).