### PR TITLE
#36 fixing code.google.com references

### DIFF
--- a/chapters/get_setup.md
+++ b/chapters/get_setup.md
@@ -76,8 +76,8 @@ Setup your path, as explained in Section~\ref{sec:setup_path}
 Installing `Godoc`, `vet` and `Golint`, three very useful Go tools from the Go team,
 is highly recommended:
 
-    $ go get code.google.com/p/go.tools/cmd/godoc
-    $ go get code.google.com/p/go.tools/cmd/vet
+    $ go get golang.org/x/tools/cmd/godoc
+    $ go get golang.org/x/tools/cmd/vet
     $ go get github.com/golang/lint/golint
 
 [Official resource](http://golang.org/doc/go1.2#go_tools_godoc)


### PR DESCRIPTION
Fixes #36 
code.google.com no longer exists.

Thanks,
Steve