### PR TITLE
update homebrew install script url

### DIFF
--- a/chapters/get_setup.md
+++ b/chapters/get_setup.md
@@ -8,7 +8,7 @@ The easiest way to install Go for development on OS X is to use
 
 Using `Terminal.app` install homebrew:
 
-    $ ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
+    $ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
 Once homebrew is installed, install Go to be able to crosscompile:
 


### PR DESCRIPTION
the original script can also run, however the 'go' in the original url seems confusing