### PR TITLE
Structures do not match description

### DIFF
--- a/chapters/types.md
+++ b/chapters/types.md
@@ -361,8 +361,10 @@ type User struct {
 }
 
 type Player struct {
-	User
-	GameId         int
+	Id       int
+	Name     string
+	Location string
+	GameId	 int
 }
 
 func main() {


### PR DESCRIPTION
As far as I can tell, you're trying to illustrate that composition prevents duplication in structures, but the pre-composition example exactly matches the post-composition example. You'll need to update the golang playground link below the example if you think this change is accurate. If not, apologies!

Signed-Off-By: Joe Handzik <joseph.t.handzik@hpe.com>