### PR TITLE
Correct one typo in basics.md 's/page/package/g' #57

### DIFF
--- a/chapters/basics.md
+++ b/chapters/basics.md
@@ -310,7 +310,7 @@ func main() {
 }
 ```
 
-`Pi` is exported and can be accessed from outside the page, while `pi`
+`Pi` is exported and can be accessed from outside the package, while `pi`
 isn't available.
 
 


### PR DESCRIPTION
This commit fixes #57 