### PR TITLE
Errant end of code block marker in tricks_and_tips.md

### DIFF
--- a/chapters/tricks_and_tips.md
+++ b/chapters/tricks_and_tips.md
@@ -531,7 +531,7 @@ func main() {
     i := 2
     fmt.Println(SoSayethThe(i))
 }
-```
+
 
 // output:
 // cannot use i (type int) as type Stereotype in argument to SoSayethThe


### PR DESCRIPTION
Errant  set of ``` in the file before a code comment.