### PR TITLE
Remove superfluous `vet` install

### DIFF
--- a/chapters/get_setup.md
+++ b/chapters/get_setup.md
@@ -73,11 +73,10 @@ Setup your path, as explained in Section~\ref{sec:setup_path}
 
 ## Extras
 
-Installing `Godoc`, `vet` and `Golint`, three very useful Go tools from the Go team,
+Installing `Godoc` and `Golint`, two very useful Go tools from the Go team,
 is highly recommended:
 
     $ go get golang.org/x/tools/cmd/godoc
-    $ go get golang.org/x/tools/cmd/vet
     $ go get github.com/golang/lint/golint
 
 [Official resource](http://golang.org/doc/go1.2#go_tools_godoc)


### PR DESCRIPTION
The `vet` tool now comes packaged in the go distribution by default, so a manual install results in this error:

```
package golang.org/x/tools/cmd/vet: cannot find package "golang.org/x/tools/cmd/vet" in any of:
	/usr/local/Cellar/go/1.9.2/libexec/src/golang.org/x/tools/cmd/vet (from $GOROOT)
	/Users/alishamayor/go/src/golang.org/x/tools/cmd/vet (from $GOPATH)
```